### PR TITLE
[codex] Gate IMSLP work recovery with deterministic QA

### DIFF
--- a/docs/ACTIVE_CONTEXT.md
+++ b/docs/ACTIVE_CONTEXT.md
@@ -4,13 +4,13 @@ This is the canonical handoff file for the next session. Rewrite freely as prior
 
 ## Current Objective
 
-Finish the pre-ingest cleanup branch, then continue IMSLP work ingestion at offset `3700` from a clean follow-on branch.
+Finish IMSLP ingestion quality gates, then continue work ingestion at offset `3700` only through the gated recovery flow.
 
 Business-strategy side note: the current monetization path as of `2026-06-27` is now documented in `docs/specs/monetization-path.md`. The current thesis is to keep the public orchestral Works Database broadly free and monetize paid workflow, organization library-management, services, API/data, and carefully labeled publisher/composer discovery layers around it.
 
 ## Current Branch
 
-- `codex/pre-ingest-cleanup`
+- `codex/imslp-quality-gates`
 
 ## Parallel Work Coordination
 
@@ -27,14 +27,12 @@ Business-strategy side note: the current monetization path as of `2026-06-27` is
 
 - Agent: current Codex session
   - Worktree: current checkout at `/Volumes/Felix-SSD-1/Cursor Projects/opusgraph`
-  - Branch: `codex/pre-ingest-cleanup`
-  - Scope: clean up pre-ingest operational risks before resuming offset `3700`
+  - Branch: `codex/imslp-quality-gates`
+  - Scope: add deterministic IMSLP pre-live QA and explicit live recovery gates before resuming offset `3700`
   - File ownership:
-    - `lib/ingest/jobs/run.ts`
+    - `scripts/qa-imslp-work-slice.ts`
     - `scripts/recover-imslp-work-slice.ts`
-    - `app/layout.tsx`
-    - `app/fonts/`
-    - `eslint.config.mjs`
+    - `scripts/audit-imslp-work-coverage.ts`
     - `docs/ACTIVE_CONTEXT.md`
     - `docs/ROADMAP.md`
     - `docs/DECISIONS.md`
@@ -44,14 +42,18 @@ Business-strategy side note: the current monetization path as of `2026-06-27` is
 
 ## In Progress
 
-- Pre-ingest cleanup before offset `3700`:
-  - operator/job finalization is being hardened so delayed final job bookkeeping no longer looks like inert zero-counter work
-  - local build determinism is being restored by removing the build-time Google Fonts fetch
-  - lint is being restored as a usable nonblocking quality gate
-  - repo-native handoff docs are being refreshed so the active state points to offset `3700`, not older completed slices
+- IMSLP quality gates before offset `3700`:
+  - all four quality-control tracks are now recorded in `docs/ROADMAP.md`
+  - `scripts/qa-imslp-work-slice.ts` is being added as the pre-live deterministic QA report for a work slice
+  - `scripts/recover-imslp-work-slice.ts` is being tightened so live recovery requires a green replay dry-run, green pre-live QA, post-live exact coverage audit, and clean duplicate-flag hygiene
+  - `scripts/audit-imslp-work-coverage.ts` is being refactored to keep the existing CLI output while also exporting a reusable audit function
+  - LLMs are being recorded as advisory-only review assistance for ingestion, not a source of DB truth
+  - staging-table ingestion is tracked as a later architecture option, not part of this branch
 
 - Monetization path documentation:
   - `docs/specs/monetization-path.md` now records the active monetization thesis plus append-only version history
+  - `docs/specs/monetization-run-rate-estimate-2026-06-27.md` preserves the first consolidated low/medium/high annualized run-rate estimate through `2035`
+  - `docs/specs/august-1-first-dollars-plan.md` records the 2026-06-27 assessment for reaching first dollars by 2026-08-01
   - `docs/DECISIONS.md` records the durable decision to monetize workflow layers around a free public Works Database
   - `docs/ROADMAP.md` includes monetization validation as a strategy track
   - next step is validation, not implementation: test individual willingness around advanced discovery/planning and organization willingness around private catalog/import/performance-history workflows

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2,6 +2,19 @@
 
 Record durable product and architecture decisions here. Keep entries brief and biased toward rationale and consequences.
 
+## 2026-06-27: LLMs may assist ingestion review but must not write source truth
+
+- Decision: Treat LLMs as advisory review assistants only for source ingestion. Deterministic parsers, validators, source identities, review flags, and human-approved promotion remain the only paths that write composer/work truth into the database.
+- Context: IMSLP work ingestion is now mature enough to continue at offset `3700`, but the largest remaining risk is silent data-quality drift from ambiguous instrumentation, years, durations, duplicate matches, redirects, or composer resolution. LLMs can help reviewers notice suspicious cases, but they are not a reliable source of record.
+- Why:
+  - keeps ingestion reproducible and auditable from source payloads, deterministic classifier output, and dry-run results
+  - prevents LLM-derived guesses from becoming canonical title, composer, instrumentation, duration, year, or scope data
+  - still allows LLMs to summarize QA reports or propose review flags when humans need triage help
+- Consequences:
+  - pre-live QA gates must be deterministic and runnable without an LLM
+  - any LLM output belongs in advisory metadata, comments, or review notes, not direct `composer`/`work` writes
+  - future staging-table work should preserve this boundary by requiring reviewed promotion before candidate data becomes canonical
+
 ## 2026-06-27: Keep the historical `00025` migration filename instead of renaming it
 
 - Decision: Do not rename `supabase/migrations/00025_auto_create_user_profile.sql`; treat it as a historical filename wart and correct documentation references to the actual file.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,9 +4,19 @@ This file is the current priority view for OpusGraph. Keep it short, current, an
 
 ## Now
 
+### August 1 first-dollars chargeable beta
+- Status: Assessment recorded
+- Spec: `docs/specs/august-1-first-dollars-plan.md`
+- Current direction:
+  - aim for first dollars from a founder-led library setup/import beta, not a broad self-serve SaaS launch
+  - use manual payment links or invoices before building full Stripe checkout
+  - prioritize demo data, import reliability, org role/security verification, and a small published reference seed set
+  - defer marketplace, AI search, self-serve billing, and large-scale public database publishing until after the first paid cohort
+
 ### Monetization path validation
 - Status: Strategy snapshot recorded
 - Spec: `docs/specs/monetization-path.md`
+- Estimate snapshot: `docs/specs/monetization-run-rate-estimate-2026-06-27.md`
 - Current direction:
   - keep the public orchestral Works Database broadly free
   - monetize paid workflow layers around serious use: advanced discovery, season planning, exports, organization library management, import services, API/data licensing, and carefully labeled publisher/composer discovery surfaces
@@ -24,6 +34,11 @@ This file is the current priority view for OpusGraph. Keep it short, current, an
   - implement IMSLP as the first source adapter for composer and work seeding
   - use source identity in `external_ids` and raw payloads in `extra_metadata`
   - route ambiguous matches into `review_flag` instead of auto-merging
+- Quality-control tracks before continuing offset `3700`:
+  - pre-live slice QA: add a deterministic dry-run report that lists every candidate that would be created or updated, including parsed title, composer, instrumentation, duration, composition year, source URL, orchestral classification, parser/processor warnings, duplicate ambiguity, redirects, duration normalization, and other risk flags
+  - explicit live recovery gates: require a green replay dry-run, a green pre-live QA gate, a post-live exact coverage audit with `0` uncovered source ids, and clean duplicate-flag hygiene before a live recovery run is considered successful
+  - LLM usage boundary: LLMs, if used at all, are review assistants only; they may help flag suspicious instrumentation or metadata for human review, but they must not directly write composer/work truth into the database
+  - later staging architecture: consider a `source_ingest_candidate` staging table if deterministic scripts and review flags stop being enough; raw source candidates would land in staging and only reviewed/promoted candidates would write into `composer`/`work`
 - Immediate task slice:
   - continue IMSLP work ingestion under the merged orchestral-only correction:
     - the IMSLP work adapter now classifies orchestral scope from instrumentation text
@@ -283,8 +298,8 @@ This file is the current priority view for OpusGraph. Keep it short, current, an
       - `0` open duplicate flags missing `details.source_identity`
       - `0` duplicate-source collisions
   - next operator step:
-    - finish the pre-ingest cleanup branch
-    - then resume at offset `3700` from a clean follow-on branch
+    - finish the IMSLP quality-gates branch
+    - then resume at offset `3700` with the gated recovery script
   - offset `2900` is operationally closed:
     - initial dry-run `386741bb-fe80-49b8-8f95-e42506b22743` settled at:
       - `0` created

--- a/scripts/audit-imslp-work-coverage.ts
+++ b/scripts/audit-imslp-work-coverage.ts
@@ -7,7 +7,6 @@ import { createClient } from "@supabase/supabase-js";
 import { ingestAdapterRegistry } from "@/lib/ingest/adapters";
 import { processIngestCandidate } from "@/app/api/admin/ingest/_shared";
 import type { WorkCandidate } from "@/lib/ingest/candidates";
-import type { CandidatePersistResult } from "@/lib/ingest/results";
 import type { IngestJobRecord } from "@/lib/ingest/jobs/types";
 import type { PersistSupabaseClient } from "@/lib/ingest/persist/support";
 
@@ -21,7 +20,7 @@ if (!SUPABASE_URL || !SUPABASE_SECRET_KEY) {
   process.exit(1);
 }
 
-interface CliArgs {
+export interface AuditImslpWorkCoverageCliArgs {
   offsetStart: number;
   offsetEnd: number;
   step: number;
@@ -41,8 +40,8 @@ interface WorkIdentityRow {
   external_ids: Record<string, unknown> | null;
 }
 
-function parseArgs(argv: string[]): CliArgs {
-  const args: CliArgs = {
+function parseArgs(argv: string[]): AuditImslpWorkCoverageCliArgs {
+  const args: AuditImslpWorkCoverageCliArgs = {
     offsetStart: 1700,
     offsetEnd: 2900,
     step: 100,
@@ -83,7 +82,10 @@ function parseArgs(argv: string[]): CliArgs {
   return args;
 }
 
-function buildSyntheticJob(args: CliArgs, offset: number): IngestJobRecord {
+function buildSyntheticJob(
+  args: AuditImslpWorkCoverageCliArgs,
+  offset: number,
+): IngestJobRecord {
   const now = new Date().toISOString();
 
   return {
@@ -248,8 +250,9 @@ async function loadImslpWorkSourceIds(
   return sourceIds;
 }
 
-async function main() {
-  const args = parseArgs(process.argv.slice(2));
+export async function auditImslpWorkCoverage(
+  args: AuditImslpWorkCoverageCliArgs,
+) {
   const supabase = createClient(SUPABASE_URL, SUPABASE_SECRET_KEY, {
     auth: {
       autoRefreshToken: false,
@@ -410,28 +413,35 @@ async function main() {
     }))
     .sort((left, right) => left.sourceId.localeCompare(right.sourceId));
 
+  return {
+    range: {
+      offsetStart: args.offsetStart,
+      offsetEnd: args.offsetEnd,
+      step: args.step,
+      batchSize: args.batchSize,
+    },
+    duplicateFlagHygiene: {
+      openDuplicateFlags: openDuplicates.length,
+      missingSourceIdentityCount: duplicateFlagsMissingSourceIdentity,
+      duplicateSourceIdentityCount: duplicateCollisions.length,
+      duplicateSourceIdentitySample: duplicateCollisions.slice(0, 20),
+    },
+    slices,
+    summary: {
+      auditedSlices: slices.length,
+      uncoveredCount: uncoveredOverall.length,
+      uncoveredSample: uncoveredOverall.slice(0, 20),
+    },
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const result = await auditImslpWorkCoverage(args);
+
   console.log(
     JSON.stringify(
-      {
-        range: {
-          offsetStart: args.offsetStart,
-          offsetEnd: args.offsetEnd,
-          step: args.step,
-          batchSize: args.batchSize,
-        },
-        duplicateFlagHygiene: {
-          openDuplicateFlags: openDuplicates.length,
-          missingSourceIdentityCount: duplicateFlagsMissingSourceIdentity,
-          duplicateSourceIdentityCount: duplicateCollisions.length,
-          duplicateSourceIdentitySample: duplicateCollisions.slice(0, 20),
-        },
-        slices,
-        summary: {
-          auditedSlices: slices.length,
-          uncoveredCount: uncoveredOverall.length,
-          uncoveredSample: uncoveredOverall.slice(0, 20),
-        },
-      },
+      result,
       null,
       2,
     ),

--- a/scripts/qa-imslp-work-slice.ts
+++ b/scripts/qa-imslp-work-slice.ts
@@ -1,0 +1,481 @@
+import { config } from "dotenv";
+import { resolve } from "path";
+import { pathToFileURL } from "url";
+
+import { createClient } from "@supabase/supabase-js";
+
+import { processIngestCandidate } from "@/app/api/admin/ingest/_shared";
+import { ingestAdapterRegistry } from "@/lib/ingest/adapters";
+import { assessImslpWorkOrchestralScope } from "@/lib/ingest/adapters/imslp/work-fields";
+import type { WorkCandidate } from "@/lib/ingest/candidates";
+import type { JsonObject } from "@/lib/ingest/domain";
+import type { IngestJobRecord } from "@/lib/ingest/jobs/types";
+import type { CandidatePersistResult } from "@/lib/ingest/results";
+
+config({ path: resolve(process.cwd(), ".env.local") });
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
+const SUPABASE_SECRET_KEY = process.env.SUPABASE_SECRET_KEY ?? "";
+
+if (!SUPABASE_URL || !SUPABASE_SECRET_KEY) {
+  console.error("Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SECRET_KEY.");
+  process.exit(1);
+}
+
+export interface QaImslpWorkSliceCliArgs {
+  offset: number;
+  batchSize: number;
+  createdBy: string;
+  allowRiskyAccepted: boolean;
+}
+
+interface QaIssueSummary {
+  code: string;
+  severity: string;
+  message: string;
+}
+
+interface QaWorkRow {
+  sourceId: string;
+  sourceUrl: string | null;
+  title: string;
+  composerDisplayName: string | null;
+  composerSourceId: string | null;
+  instrumentationText: string | null;
+  durationText: string | null;
+  rawDurationText: string | null;
+  compositionYear: number | null;
+  compositionYearText: string | null;
+  pageRedirectTitle: string | null;
+  orchestralScope: {
+    classification: string;
+    reason: string;
+    matchedSignals: string[];
+    normalizedInstrumentationText: string | null;
+  };
+  dryRunOutcome: CandidatePersistResult["outcome"];
+  issueCodes: string[];
+  warnings: QaIssueSummary[];
+  issues: QaIssueSummary[];
+  duplicateEntityIds: string[];
+  riskFlags: string[];
+  isAcceptedWrite: boolean;
+  isRiskyAcceptedWrite: boolean;
+}
+
+export interface QaImslpWorkSliceResult {
+  offset: number;
+  batchSize: number;
+  gate: {
+    passed: boolean;
+    allowRiskyAccepted: boolean;
+    failedCount: number;
+    riskyAcceptedWriteCount: number;
+    acceptedWriteCount: number;
+  };
+  summary: {
+    candidateCount: number;
+    outcomeCounts: Record<string, number>;
+    acceptedWriteCount: number;
+    riskyAcceptedWriteCount: number;
+    failedCount: number;
+    quarantineCount: number;
+    duplicateCount: number;
+    warningCount: number;
+    riskFlagCounts: Record<string, number>;
+  };
+  rows: QaWorkRow[];
+  riskyAcceptedSample: QaWorkRow[];
+  failedSample: QaWorkRow[];
+  duplicateSample: QaWorkRow[];
+}
+
+function readBoolean(value: string): boolean {
+  return value === "true" || value === "1";
+}
+
+function parseArgs(argv: string[]): QaImslpWorkSliceCliArgs {
+  const defaults: QaImslpWorkSliceCliArgs = {
+    offset: 0,
+    batchSize: 100,
+    createdBy: "f2ed501c-74ad-4c2e-bb66-c97f5a6aa0ba",
+    allowRiskyAccepted: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const next = argv[index + 1];
+
+    switch (token) {
+      case "--offset":
+        defaults.offset = Number.parseInt(next ?? String(defaults.offset), 10);
+        index += 1;
+        break;
+      case "--batch-size":
+        defaults.batchSize = Number.parseInt(next ?? String(defaults.batchSize), 10);
+        index += 1;
+        break;
+      case "--created-by":
+        defaults.createdBy = next ?? defaults.createdBy;
+        index += 1;
+        break;
+      case "--allow-risky-accepted":
+        defaults.allowRiskyAccepted = readBoolean(
+          next ?? String(defaults.allowRiskyAccepted),
+        );
+        index += 1;
+        break;
+      default:
+        break;
+    }
+  }
+
+  return defaults;
+}
+
+function buildSyntheticJob(args: QaImslpWorkSliceCliArgs): IngestJobRecord {
+  const now = new Date().toISOString();
+
+  return {
+    id: `synthetic:qa-imslp-work:${args.offset}`,
+    source: "imslp",
+    entityKind: "work",
+    status: "running",
+    mode: "manual",
+    priority: 100,
+    dryRun: true,
+    cursor: {
+      version: 1,
+      strategy: "offset",
+      offset: args.offset,
+      batchSize: args.batchSize,
+      sort: "id",
+      sourceEntityKind: "work",
+    },
+    options: {
+      sourceEntityKind: "work",
+    },
+    batchSize: args.batchSize,
+    limitCount: null,
+    processedCount: 0,
+    createdCount: 0,
+    updatedCount: 0,
+    flaggedCount: 0,
+    failedCount: 0,
+    skippedCount: 0,
+    warningCount: 0,
+    errorSummary: null,
+    warningSummary: null,
+    resultSummary: null,
+    attemptCount: 1,
+    lastErrorAt: null,
+    nextRetryAt: null,
+    claimedBy: "manual:qa-imslp-work-slice",
+    claimedAt: now,
+    lastHeartbeatAt: now,
+    createdBy: args.createdBy,
+    startedAt: now,
+    finishedAt: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function readRecord(value: unknown): JsonObject | null {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  return value as JsonObject;
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+function readExtractedFields(candidate: WorkCandidate): JsonObject | null {
+  const metadata = readRecord(candidate.extraMetadata);
+  return readRecord(metadata?.extracted_fields);
+}
+
+function readCompositionYearText(candidate: WorkCandidate): string | null {
+  const fields = readExtractedFields(candidate);
+  return readString(fields?.composition_year_text);
+}
+
+function readPageRedirectTitle(candidate: WorkCandidate): string | null {
+  const metadata = readRecord(candidate.extraMetadata);
+  const page = readRecord(metadata?.page);
+  return readString(page?.redirect_title);
+}
+
+function readRawDurationText(candidate: WorkCandidate): string | null {
+  const fields = readExtractedFields(candidate);
+  const rawFields = readRecord(fields?.raw_fields);
+  return readString(rawFields?.["Average Duration"]);
+}
+
+function summarizeIssues(
+  issues: CandidatePersistResult["issues"],
+): QaIssueSummary[] {
+  return issues.map((issue) => ({
+    code: issue.code,
+    severity: issue.severity,
+    message: issue.message,
+  }));
+}
+
+function readDuplicateEntityIds(result: CandidatePersistResult): string[] {
+  if (result.outcome !== "flagged_duplicate") {
+    return [];
+  }
+
+  return result.duplicateEntityIds;
+}
+
+function isAcceptedWrite(outcome: CandidatePersistResult["outcome"]): boolean {
+  return (
+    outcome === "created" ||
+    outcome === "updated" ||
+    outcome === "skipped_existing_source_match"
+  );
+}
+
+function riskFlagsForRow(args: {
+  candidate: WorkCandidate;
+  result: CandidatePersistResult;
+  compositionYearText: string | null;
+  rawDurationText: string | null;
+  pageRedirectTitle: string | null;
+}): string[] {
+  const { candidate, result, compositionYearText, rawDurationText, pageRedirectTitle } =
+    args;
+  const scope = assessImslpWorkOrchestralScope(candidate.instrumentationText);
+  const accepted = isAcceptedWrite(result.outcome);
+  const flags: string[] = [];
+
+  if (result.outcome === "failed_parse" || result.outcome === "failed_write") {
+    flags.push("dry_run_failed");
+  }
+
+  if (result.outcome === "flagged_duplicate") {
+    flags.push("duplicate_ambiguity");
+  }
+
+  if (!candidate.instrumentationText?.trim()) {
+    flags.push("missing_instrumentation");
+  }
+
+  if (scope.classification === "unknown") {
+    flags.push("unknown_orchestral_scope");
+  }
+
+  if (scope.reason === "ambiguous_orchestral_reference_only") {
+    flags.push("ambiguous_orchestral_reference");
+  }
+
+  if (compositionYearText && candidate.compositionYear == null) {
+    flags.push("ambiguous_or_unparsed_year");
+  }
+
+  if (
+    rawDurationText &&
+    candidate.durationText &&
+    rawDurationText.trim() !== candidate.durationText.trim()
+  ) {
+    flags.push("duration_normalized");
+  }
+
+  if (pageRedirectTitle) {
+    flags.push("page_redirect");
+  }
+
+  if (!candidate.composerSourceId?.trim()) {
+    flags.push("composer_source_id_missing");
+  }
+
+  if (accepted && scope.classification !== "orchestral") {
+    flags.push("accepted_not_confirmed_orchestral");
+  }
+
+  if (accepted && candidate.warnings.length > 0) {
+    flags.push("accepted_with_candidate_warnings");
+  }
+
+  if (accepted && result.issues.length > 0) {
+    flags.push("accepted_with_processing_issues");
+  }
+
+  return flags;
+}
+
+function countBy(rows: string[]): Record<string, number> {
+  return rows.reduce<Record<string, number>>((acc, value) => {
+    acc[value] = (acc[value] ?? 0) + 1;
+    return acc;
+  }, {});
+}
+
+export async function qaImslpWorkSlice(
+  args: QaImslpWorkSliceCliArgs,
+): Promise<QaImslpWorkSliceResult> {
+  const adapter = ingestAdapterRegistry.imslp;
+
+  if (!adapter) {
+    throw new Error("Missing IMSLP adapter.");
+  }
+
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SECRET_KEY, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+
+  const fetched = await adapter.fetchBatch({
+    entityKind: "work",
+    cursor: {
+      version: 1,
+      strategy: "offset",
+      offset: args.offset,
+      batchSize: args.batchSize,
+      sort: "id",
+      sourceEntityKind: "work",
+    },
+    batchSize: args.batchSize,
+    options: {
+      sourceEntityKind: "work",
+    },
+  });
+
+  const parsed = await adapter.parseBatch({
+    entityKind: "work",
+    items: fetched.items,
+    options: {
+      sourceEntityKind: "work",
+    },
+  });
+
+  const job = buildSyntheticJob(args);
+  const rows: QaWorkRow[] = [];
+
+  for (const candidate of parsed.candidates) {
+    if (candidate.entityKind !== "work") {
+      continue;
+    }
+
+    const result = await processIngestCandidate({
+      supabase,
+      candidate,
+      job,
+      actorUserId: args.createdBy,
+      dryRun: true,
+    });
+    const scope = assessImslpWorkOrchestralScope(candidate.instrumentationText);
+    const compositionYearText = readCompositionYearText(candidate);
+    const rawDurationText = readRawDurationText(candidate);
+    const pageRedirectTitle = readPageRedirectTitle(candidate);
+    const riskFlags = riskFlagsForRow({
+      candidate,
+      result,
+      compositionYearText,
+      rawDurationText,
+      pageRedirectTitle,
+    });
+    const accepted = isAcceptedWrite(result.outcome);
+    const riskyAccepted = accepted && riskFlags.length > 0;
+
+    rows.push({
+      sourceId: candidate.sourceIdentity.sourceId,
+      sourceUrl: candidate.sourceIdentity.sourceUrl ?? null,
+      title: candidate.title,
+      composerDisplayName: candidate.composerDisplayName ?? null,
+      composerSourceId: candidate.composerSourceId ?? null,
+      instrumentationText: candidate.instrumentationText ?? null,
+      durationText: candidate.durationText ?? null,
+      rawDurationText,
+      compositionYear: candidate.compositionYear ?? null,
+      compositionYearText,
+      pageRedirectTitle,
+      orchestralScope: {
+        classification: scope.classification,
+        reason: scope.reason,
+        matchedSignals: scope.matchedSignals,
+        normalizedInstrumentationText: scope.normalizedInstrumentationText,
+      },
+      dryRunOutcome: result.outcome,
+      issueCodes: result.issues.map((issue) => issue.code),
+      warnings: summarizeIssues(candidate.warnings),
+      issues: summarizeIssues(result.issues),
+      duplicateEntityIds: readDuplicateEntityIds(result),
+      riskFlags,
+      isAcceptedWrite: accepted,
+      isRiskyAcceptedWrite: riskyAccepted,
+    });
+  }
+
+  const outcomeCounts = countBy(rows.map((row) => row.dryRunOutcome));
+  const riskFlagCounts = countBy(rows.flatMap((row) => row.riskFlags));
+  const failedRows = rows.filter(
+    (row) =>
+      row.dryRunOutcome === "failed_parse" || row.dryRunOutcome === "failed_write",
+  );
+  const riskyAcceptedRows = rows.filter((row) => row.isRiskyAcceptedWrite);
+  const gatePassed =
+    failedRows.length === 0 &&
+    (args.allowRiskyAccepted || riskyAcceptedRows.length === 0);
+
+  return {
+    offset: args.offset,
+    batchSize: args.batchSize,
+    gate: {
+      passed: gatePassed,
+      allowRiskyAccepted: args.allowRiskyAccepted,
+      failedCount: failedRows.length,
+      riskyAcceptedWriteCount: riskyAcceptedRows.length,
+      acceptedWriteCount: rows.filter((row) => row.isAcceptedWrite).length,
+    },
+    summary: {
+      candidateCount: rows.length,
+      outcomeCounts,
+      acceptedWriteCount: rows.filter((row) => row.isAcceptedWrite).length,
+      riskyAcceptedWriteCount: riskyAcceptedRows.length,
+      failedCount: failedRows.length,
+      quarantineCount: rows.filter((row) => row.dryRunOutcome === "quarantined").length,
+      duplicateCount: rows.filter((row) => row.dryRunOutcome === "flagged_duplicate")
+        .length,
+      warningCount: rows.reduce((total, row) => total + row.warnings.length, 0),
+      riskFlagCounts,
+    },
+    rows,
+    riskyAcceptedSample: riskyAcceptedRows.slice(0, 20),
+    failedSample: failedRows.slice(0, 20),
+    duplicateSample: rows
+      .filter((row) => row.dryRunOutcome === "flagged_duplicate")
+      .slice(0, 20),
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const result = await qaImslpWorkSlice(args);
+
+  console.log(JSON.stringify(result, null, 2));
+  if (!result.gate.passed) {
+    process.exit(1);
+  }
+}
+
+function isMainModule() {
+  const entry = process.argv[1];
+  return entry != null && import.meta.url === pathToFileURL(entry).href;
+}
+
+if (isMainModule()) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/scripts/recover-imslp-work-slice.ts
+++ b/scripts/recover-imslp-work-slice.ts
@@ -4,6 +4,14 @@ import { resolve } from "path";
 import { runIngestJob } from "./run-ingest-job";
 import { inspectImslpWorkSlice } from "./inspect-imslp-work-slice";
 import { seedMissingWorkComposers } from "./seed-imslp-work-composers";
+import {
+  auditImslpWorkCoverage,
+  type AuditImslpWorkCoverageCliArgs,
+} from "./audit-imslp-work-coverage";
+import {
+  qaImslpWorkSlice,
+  type QaImslpWorkSliceResult,
+} from "./qa-imslp-work-slice";
 
 config({ path: resolve(process.cwd(), ".env.local") });
 
@@ -12,6 +20,11 @@ interface CliArgs {
   batchSize: number;
   createdBy: string;
   runLive: boolean;
+  requireQa: boolean;
+  allowRiskyAccepted: boolean;
+  requirePostLiveAudit: boolean;
+  postLiveAuditAttempts: number;
+  postLiveAuditDelayMs: number;
 }
 
 function readBoolean(value: string): boolean {
@@ -24,6 +37,11 @@ function parseArgs(argv: string[]): CliArgs {
     batchSize: 100,
     createdBy: "f2ed501c-74ad-4c2e-bb66-c97f5a6aa0ba",
     runLive: true,
+    requireQa: true,
+    allowRiskyAccepted: false,
+    requirePostLiveAudit: true,
+    postLiveAuditAttempts: 3,
+    postLiveAuditDelayMs: 5000,
   };
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -45,6 +63,36 @@ function parseArgs(argv: string[]): CliArgs {
         break;
       case "--run-live":
         defaults.runLive = readBoolean(next ?? String(defaults.runLive));
+        index += 1;
+        break;
+      case "--require-qa":
+        defaults.requireQa = readBoolean(next ?? String(defaults.requireQa));
+        index += 1;
+        break;
+      case "--allow-risky-accepted":
+        defaults.allowRiskyAccepted = readBoolean(
+          next ?? String(defaults.allowRiskyAccepted),
+        );
+        index += 1;
+        break;
+      case "--require-post-live-audit":
+        defaults.requirePostLiveAudit = readBoolean(
+          next ?? String(defaults.requirePostLiveAudit),
+        );
+        index += 1;
+        break;
+      case "--post-live-audit-attempts":
+        defaults.postLiveAuditAttempts = Number.parseInt(
+          next ?? String(defaults.postLiveAuditAttempts),
+          10,
+        );
+        index += 1;
+        break;
+      case "--post-live-audit-delay-ms":
+        defaults.postLiveAuditDelayMs = Number.parseInt(
+          next ?? String(defaults.postLiveAuditDelayMs),
+          10,
+        );
         index += 1;
         break;
       default:
@@ -103,6 +151,81 @@ function summarizeRunResult(result: Awaited<ReturnType<typeof runIngestJob>>) {
     warningSummary: result.warningSummary,
     resultSummary: result.resultSummary,
   };
+}
+
+function summarizeQaResult(result: QaImslpWorkSliceResult) {
+  return {
+    offset: result.offset,
+    batchSize: result.batchSize,
+    gate: result.gate,
+    summary: result.summary,
+    riskyAcceptedSample: result.riskyAcceptedSample,
+    failedSample: result.failedSample,
+    duplicateSample: result.duplicateSample,
+  };
+}
+
+function postLiveAuditGatePassed(
+  result: Awaited<ReturnType<typeof auditImslpWorkCoverage>>,
+): boolean {
+  return (
+    result.summary.uncoveredCount === 0 &&
+    result.duplicateFlagHygiene.missingSourceIdentityCount === 0 &&
+    result.duplicateFlagHygiene.duplicateSourceIdentityCount === 0
+  );
+}
+
+function sleep(ms: number) {
+  return new Promise((resolvePromise) => {
+    setTimeout(resolvePromise, ms);
+  });
+}
+
+async function runPostLiveAuditWithRetries(
+  args: CliArgs,
+): Promise<Awaited<ReturnType<typeof auditImslpWorkCoverage>>> {
+  const auditArgs: AuditImslpWorkCoverageCliArgs = {
+    offsetStart: args.offset,
+    offsetEnd: args.offset,
+    step: args.batchSize,
+    batchSize: args.batchSize,
+    createdBy: args.createdBy,
+  };
+  const attempts = Math.max(1, args.postLiveAuditAttempts);
+  let latest: Awaited<ReturnType<typeof auditImslpWorkCoverage>> | null = null;
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    logStage("post_live_audit_started", {
+      offset: args.offset,
+      batchSize: args.batchSize,
+      attempt,
+      attempts,
+    });
+
+    latest = await auditImslpWorkCoverage(auditArgs);
+
+    logStage("post_live_audit_finished", {
+      attempt,
+      attempts,
+      uncoveredCount: latest.summary.uncoveredCount,
+      missingDuplicateSourceIdentityCount:
+        latest.duplicateFlagHygiene.missingSourceIdentityCount,
+      duplicateSourceIdentityCount:
+        latest.duplicateFlagHygiene.duplicateSourceIdentityCount,
+    });
+
+    if (postLiveAuditGatePassed(latest) || attempt === attempts) {
+      return latest;
+    }
+
+    await sleep(Math.max(0, args.postLiveAuditDelayMs));
+  }
+
+  if (!latest) {
+    throw new Error("Post-live audit did not run.");
+  }
+
+  return latest;
 }
 
 function logStage(stage: string, data?: Record<string, unknown>) {
@@ -231,7 +354,47 @@ async function main() {
     process.exit(1);
   }
 
+  let preLiveQa: QaImslpWorkSliceResult | null = null;
+  if (args.runLive && args.requireQa) {
+    logStage("pre_live_qa_started", {
+      offset: args.offset,
+      batchSize: args.batchSize,
+      allowRiskyAccepted: args.allowRiskyAccepted,
+    });
+
+    preLiveQa = await qaImslpWorkSlice({
+      offset: args.offset,
+      batchSize: args.batchSize,
+      createdBy: args.createdBy,
+      allowRiskyAccepted: args.allowRiskyAccepted,
+    });
+
+    logStage("pre_live_qa_finished", {
+      gate: preLiveQa.gate,
+      summary: preLiveQa.summary,
+    });
+
+    if (!preLiveQa.gate.passed) {
+      console.log(
+        JSON.stringify(
+          {
+            stage: "pre_live_qa_gate_failed",
+            initialDryRun: summarizeRunResult(initialDryRun),
+            seedResult,
+            replayDryRun: summarizeRunResult(replayDryRun),
+            preLiveQa: summarizeQaResult(preLiveQa),
+          },
+          null,
+          2,
+        ),
+      );
+      process.exit(1);
+    }
+  }
+
   let liveRun: Awaited<ReturnType<typeof runIngestJob>> | null = null;
+  let postLiveAudit: Awaited<ReturnType<typeof auditImslpWorkCoverage>> | null =
+    null;
   if (args.runLive) {
     logStage("live_run_started", {
       offset: args.offset,
@@ -269,6 +432,29 @@ async function main() {
       );
       process.exit(1);
     }
+
+    if (args.requirePostLiveAudit) {
+      postLiveAudit = await runPostLiveAuditWithRetries(args);
+
+      if (!postLiveAuditGatePassed(postLiveAudit)) {
+        console.log(
+          JSON.stringify(
+            {
+              stage: "post_live_audit_gate_failed",
+              initialDryRun: summarizeRunResult(initialDryRun),
+              seedResult,
+              replayDryRun: summarizeRunResult(replayDryRun),
+              preLiveQa: preLiveQa ? summarizeQaResult(preLiveQa) : null,
+              liveRun: summarizeRunResult(liveRun),
+              postLiveAudit,
+            },
+            null,
+            2,
+          ),
+        );
+        process.exit(1);
+      }
+    }
   }
 
   console.log(
@@ -280,7 +466,9 @@ async function main() {
         initialDryRun: summarizeRunResult(initialDryRun),
         seedResult,
         replayDryRun: summarizeRunResult(replayDryRun),
+        preLiveQa: preLiveQa ? summarizeQaResult(preLiveQa) : null,
         liveRun: liveRun ? summarizeRunResult(liveRun) : null,
+        postLiveAudit,
       },
       null,
       2,


### PR DESCRIPTION
## Summary
- Add a deterministic IMSLP work-slice QA script that dry-runs every parsed candidate and reports source identity, parsed metadata, orchestral classification, processor issues, duplicate ambiguity, and risk flags.
- Make live recovery require a clean replay dry-run, green pre-live QA, post-live exact coverage, and duplicate-flag hygiene before the wrapper reports success.
- Refactor the coverage audit so the existing CLI behavior remains intact while recovery can reuse the exact audit programmatically.
- Record the roadmap quality tracks and codify the ingestion LLM boundary: advisory review only, never direct composer/work DB truth.

## Validation
- `npx tsc --noEmit`
- `npm run lint` exits 0 with the existing warning baseline
- `npm run build`
- `npx tsx scripts/qa-imslp-work-slice.ts --offset 3700 --batch-size 100` intentionally blocked the slice: 29 dry-run failures and 1 risky accepted write
- `npx tsx scripts/audit-imslp-work-coverage.ts --offset-start 3600 --offset-end 3600 --step 100 --batch-size 100` ran after the refactor and currently reports 8 uncovered candidates in live data, reinforcing the need for this gate before future slices

## Notes
- This PR does not push or stage unrelated monetization docs or local tool dot-directories.